### PR TITLE
[Adam Hawkins guest post] Purely visual formatting fixes to break up block of text

### DIFF
--- a/content/blog/adam-hawkins-on-pixie/adam-hawkins-on-pixie.md
+++ b/content/blog/adam-hawkins-on-pixie/adam-hawkins-on-pixie.md
@@ -36,33 +36,38 @@ these are different than Pixie becauase:
 
 * They require application code changes (like adding in
   client library or annotating Kubernetes manifests) to gather full
-  telemetry
-* They're largely GUI driven
+  telemetry.
+* They're largely GUI driven.
 * Telemetry is collected then shipped off to a centralized service
-  (which drives up the cost)
+  (which drives up the cost).
 
-Pixie is radically different. First, it integrates with eBPF so it can
+Pixie is radically different. 
+
+* First, it integrates with eBPF so it can
 collect data about application traffic without application code
 changes.  Pixie provides common HTTP telemetry (think request counts,
 latencies, and status codes) for all services running on your
 Kubernetes cluster.  Better yet, Pixie generates service to service
-telemetry, so you're given a service map right out of the box. Second,
-it bakes infrastructure-as-code principles into the core DX. Every
+telemetry, so you're given a service map right out of the box. 
+* Second, it bakes infrastructure-as-code principles into the core DX. Every
 Pixie Dashboard is a program, which you can manage with version
 control and distribute amongst your team, or even take with to
 different teams. Pixie also provides a terminal interface so you can
 interact with the dashboards directly in the CLI. That's a first for
 me and I loved it! These same scripts can also run in the browser.
-Third, and lastly, Pixie's data storage and pricing model is
+* Third, and lastly, Pixie's data storage and pricing model is
 different. Pixie keeps all telemetry data on your cluster, as a result
 the cost is signicantly lower. It's easy to pay $XXX,XXX dollars per
 year for other tools. Pixie's cost promises to be orders of
 magnitude less.
 
-Sounds interesting right? Check out my demo video for quick
+Sounds interesting right? 
+
+Check out my demo video for quick
 walkthrough.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/_MlD-hVjVok" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 
 Pixie is in free community beta right now. You can install it on your
 cluster and try it for yourself.


### PR DESCRIPTION
Before:
<img width="1286" alt="Screen Shot 2020-09-10 at 10 38 58 PM" src="https://user-images.githubusercontent.com/66266496/92869826-129c8100-f3b8-11ea-99b6-55d896ae6c2b.png">

After:
<img width="1286" alt="Screen Shot 2020-09-10 at 10 44 08 PM" src="https://user-images.githubusercontent.com/66266496/92869850-192af880-f3b8-11ea-9a4a-095910c2f402.png">
