### PR TITLE
Update font size for inline code blocks to be larger

### DIFF
--- a/src/components/mdxComponents/codeRenderer.tsx
+++ b/src/components/mdxComponents/codeRenderer.tsx
@@ -43,6 +43,7 @@ const CodeRenderer = withStyles((theme) => ({
     backgroundColor: theme.palette.type === 'light' ? '#f3f3f3' : '#292929',
     borderRadius: '5px',
     boxShadow: theme.palette.type === 'light' ? '0 2px 2px rgba(0,0,0, 0.15)' : '0px 4px 16px rgba(0, 0, 0, 0.15)',
+    fontSize: theme.typography.body2.fontSize,
     marginBottom: '32px',
     marginTop: '12px',
     position: 'relative',


### PR DESCRIPTION
Signed-off-by: Natalie Serrino <nserrino@pixielabs.ai>

The previous code block font size wasn't that readable because it was so small. Turns out we never updated it after increasing our font size elsewhere (such as body1,2, etc). 

body1.fontSize was a bit large but body2.fontSize looked right for the job.

![image](https://user-images.githubusercontent.com/5460125/138141917-dc9bdfab-1924-4aaa-add1-de1062c538fb.png)
