### PR TITLE
Remember dark/light mode setting between reloads.

### DIFF
--- a/src/components/mainThemeProvider.tsx
+++ b/src/components/mainThemeProvider.tsx
@@ -22,16 +22,26 @@ import { createMuiTheme, ThemeOptions } from '@material-ui/core';
 
 import AppThemeOptions from './theme';
 
+const canUseLocalStorage = typeof window !== 'undefined' && !!window.localStorage;
+
 function setManualPreference(mode: 'light'|'dark') {
+  if (!canUseLocalStorage) {
+    return;
+  }
+
   if (mode === 'light') {
-    localStorage.removeItem('theme');
+    window.localStorage.removeItem('theme');
   } else {
-    localStorage.setItem('theme', 'dark');
+    window.localStorage.setItem('theme', 'dark');
   }
 }
 
 function selectTheme(): 'light'|'dark' {
-  if (localStorage.getItem('theme') === 'dark') {
+  if (!canUseLocalStorage) {
+    return 'light';
+  }
+
+  if (window.localStorage.getItem('theme') === 'dark') {
     return 'dark';
   }
   return 'light';


### PR DESCRIPTION
Clicking the theme selector now saves the preference in localStorage. This preference is remembered on page load. Since light mode is default, the item is removed when choosing light mode.

Fixes #205 

Signed-off-by: Nick Lanam <nlanam@pixielabs.ai>