### PR TITLE
Remove printk in blog code snippet

### DIFF
--- a/content/blog/ebpf-portability/index.md
+++ b/content/blog/ebpf-portability/index.md
@@ -43,7 +43,6 @@ BPF_HASH(counts_by_pid, uint32_t, int64_t);
 // Probe that counts every time it is triggered.
 // Can be used to count things like syscalls or particular functions.
 int syscall__probe_counter(struct pt_regs* ctx) {
-  bpf_trace_printk("triggered");
   uint32_t tgid = bpf_get_current_pid_tgid() >> 32;
 
   int64_t kInitVal = 0;


### PR DESCRIPTION
Remove a printk that leaked through.

Signed-off-by: Omid Azizi <oazizi@pixielabs.ai>