### PR TITLE
Fix mobile cookie consent popup styling

### DIFF
--- a/src/components/cookies-consent-banner.tsx
+++ b/src/components/cookies-consent-banner.tsx
@@ -39,9 +39,6 @@ const CookiesConsentBanner = () => {
           color: 'white',
           opacity: 0.9,
           textAlign: 'center',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
           p: 2,
           fontSize: 14,
         }}
@@ -57,7 +54,26 @@ const CookiesConsentBanner = () => {
           use of cookies
         </a>
         .
-        <Button sx={{ ml: 4 }} type='button' onClick={() => close()} size='small' variant='contained'>
+        <Button
+          sx={{
+            display: {
+              xs: 'block',
+              sm: 'inline-block',
+            },
+            mx: {
+              xs: 'auto',
+              sm: 2,
+            },
+            mt: {
+              xs: 2,
+              sm: 0,
+            },
+          }}
+          type='button'
+          onClick={() => close()}
+          size='small'
+          variant='contained'
+        >
           Close
         </Button>
       </Box>


### PR DESCRIPTION
Fixes #299. 

New styling of the cookie consent popup:
![IMG_B36E66579CC9-1](https://user-images.githubusercontent.com/66266496/168722380-4ba4a061-eead-443d-a8c7-f554a003a038.jpeg)

