### PR TITLE
Update blog's frontmatter URI to match the directory structure

### DIFF
--- a/content/blog/ebpf-probes-and-you/index.md
+++ b/content/blog/ebpf-probes-and-you/index.md
@@ -1,5 +1,5 @@
 ---
-path: '/epbf-probes-and-you-navigating-linux'
+path: '/ebpf-probes-and-you'
 title: 'eBPF Probes and You: Navigating the kernel source for tracing'
 date: 2024-09-9T06:00:00.000+00:00
 featured_image: hero.png

--- a/content/blog/ebpf-tls-tracing-past-present-future/index.md
+++ b/content/blog/ebpf-tls-tracing-past-present-future/index.md
@@ -1,5 +1,5 @@
 ---
-path: '/tls-tracing-past-present-future'
+path: '/ebpf-tls-tracing-past-present-future'
 title: 'eBPF TLS tracing: The Past, Present and Future'
 date: 2024-08-12T06:00:00.000+00:00
 featured_image: hero-image.png


### PR DESCRIPTION
Through the process of debugging why Hackernews posts are linking to the wrong post, I realized that the "eBPF TLS tracing: The Past, Present and Future" and "eBPF Probes and You: Navigating the kernel source for tracing" posts are one of the few posts that have their frontmatter inconsistent with the directory structure.

Our code seems to use the directory path as the URI (loading the blog posts confirms this), so the frontmatter is not used. While I don't have proof this is causing the strange Hackernews behavior, I do know that my "Keeping prod observable" post was posted properly. The pages I fixed in this PR had the incorrect meta tag issue as seen in the screenshots below:

  
![hackernews](https://github.com/user-attachments/assets/de92f3a1-39fa-47ea-bbd9-a85867f25e7e)
